### PR TITLE
updated handling of doctr structure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,202 @@
-# Replace this file with the actual license information of the app
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2024 CLAMS Team at Brandeis Lab for Linguistics and Computation
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/app.py
+++ b/app.py
@@ -22,9 +22,17 @@ class DoctrWrapper(ClamsApp):
 
     def __init__(self):
         super().__init__()
+        # default docTR configs: 
+        # det_arch='db_resnet50' (keeping it)
+        # reco_arch='crnn_vgg16_bn', 
+        # pretrained=False, 
+        # paragraph_break=0.035, (keeping it)
+        # assume_straight_pages=True
+        # detect_orientation=False, 
         self.reader = ocr_predictor(det_arch='db_resnet50', reco_arch='parseq',
-                                    pretrained=True, detect_orientation=True, paragraph_break=0.035,
-                                    assume_straight_pages=True)
+                                    pretrained=True, 
+                                    paragraph_break=0.035,
+                                    assume_straight_pages=False, detect_orientation=True)
         if torch.cuda.is_available():
             self.gpu = True
             self.reader = self.reader.cuda().half()

--- a/app.py
+++ b/app.py
@@ -112,7 +112,8 @@ class DoctrWrapper(ClamsApp):
                 for word in line.words:
                     s = text_content.find(word.value, e)
                     e = s + len(word.value)
-                    token_ann = new_view.new_annotation(Uri.TOKEN, document=td_id, start=s, end=e, text=word.value)
+                    token_ann = new_view.new_annotation(Uri.TOKEN, document=td_id,
+                                                        start=s, end=e, text=word.value, word=word.value)
                     target_tokens.append(token_ann.id)
                     self.create_bbox(new_view, self.rel_coords_to_abs(word.geometry, w, h), representative, token_ann)
                 sent_ann.add_property("targets", target_tokens)
@@ -140,6 +141,15 @@ class DoctrWrapper(ClamsApp):
         with ThreadPoolExecutor() as executor:
             futures = []
             for timeframe in input_view.get_annotations(AnnotationTypes.TimeFrame):
+                if 'label' in timeframe:
+                    self.logger.debug(f'Found a time frame "{timeframe.id}" of label: "{timeframe.get("label")}"')
+                else:
+                    self.logger.debug(f'Found a time frame "{timeframe.id}" without label')
+                if parameters.get("tfLabel") and \
+                        'label' in timeframe and timeframe.get("label") not in parameters.get("tfLabel"):
+                    continue
+                else:
+                    self.logger.debug(f'Processing time frame "{timeframe.id}"')
                 for rep_id in timeframe.get("representatives"):
                     if Mmif.id_delimiter not in rep_id:
                         rep_id = f'{input_view.id}{Mmif.id_delimiter}{rep_id}'

--- a/metadata.py
+++ b/metadata.py
@@ -22,7 +22,7 @@ def appmetadata() -> AppMetadata:
     :return: AppMetadata object holding all necessary information.
     """
     metadata = AppMetadata(
-        name="docTR Wrapper",
+        name="CLAMS docTR Wrapper",
         description='CLAMS app wraps the docTR, End-to-End OCR model, available at '
                     'https://pypi.org/project/python-doctr . The model is capable of detecting text regions in the '
                     'input image and recognizing text in the regions. The text-localized regions are organized '
@@ -30,7 +30,7 @@ def appmetadata() -> AppMetadata:
                     'translated into `TextDocument`, `Paragraphs`, `Sentence`, and `Token` annotations that represent '
                     'recognized text contents, then aligned to `BoundingBox` annotations that represent the detected '
                     'geometries.',
-        app_license="MIT",
+        app_license="Apache 2.0",
         identifier="doctr-wrapper",
         url="https://github.com/clamsproject/app-doctr-wrapper",
         analyzer_version='0.8.1',

--- a/metadata.py
+++ b/metadata.py
@@ -23,7 +23,13 @@ def appmetadata() -> AppMetadata:
     """
     metadata = AppMetadata(
         name="docTR Wrapper",
-        description="End to end OCR for extracting text from timeframes",
+        description='CLAMS app wraps the docTR, End-to-End OCR model, available at '
+                    'https://pypi.org/project/python-doctr . The model is capable of detecting text regions in the '
+                    'input image and recognizing text in the regions. The text-localized regions are organized '
+                    'hierarchically by the model into "pages" > "blocks" > "lines" > "words", and this CLAMS app '
+                    'translated into `TextDocument`, `Paragraphs`, `Sentence`, and `Token` annotations that represent '
+                    'recognized text contents, then aligned to `BoundingBox` annotations that represent the detected '
+                    'geometries.',
         app_license="MIT",
         identifier="doctr-wrapper",
         url="https://github.com/clamsproject/app-doctr-wrapper",
@@ -31,13 +37,29 @@ def appmetadata() -> AppMetadata:
         analyzer_license="Apache 2.0",
     )
     metadata.add_input(DocumentTypes.VideoDocument)
-    metadata.add_input(AnnotationTypes.TimeFrame)
+    in_tf = metadata.add_input(AnnotationTypes.TimeFrame, representatives='?')
+    in_tf.add_description('The Time frame annotation that represents the video segment to be processed. When '
+                          '`representatives` property is present, the app will process videos still frames at the '
+                          'underlying time point annotations that are referred to by the `representatives` property. '
+                          'Otherwise, the app will process the middle frame of the video segment.')
     metadata.add_output(DocumentTypes.TextDocument)
-    metadata.add_output(at_type=Uri.SENTENCE)
-    metadata.add_output(at_type=Uri.PARAGRAPH)
-    metadata.add_output(at_type=Uri.TOKEN)
-    metadata.add_output(AnnotationTypes.Alignment)
-    metadata.add_output(AnnotationTypes.BoundingBox)
+    out_sent = metadata.add_output(at_type=Uri.SENTENCE)
+    out_sent.add_description('Translation of the recognized "text lines" in the processed input images')
+    out_para = metadata.add_output(at_type=Uri.PARAGRAPH)
+    out_para.add_description('Translation of the recognized "text blocks" in the processed input images')
+    out_tkn = metadata.add_output(at_type=Uri.TOKEN)
+    out_tkn.add_description('Translation of the recognized "text words" in the processed input images')
+    out_ali = metadata.add_output(AnnotationTypes.Alignment)
+    out_ali.add_description('Alignments between 1) `TimePoint` <-> `TextDocument`, 2) `TimePoint` <-> '
+                            '`Token`/`Sentence`/`Paragraph`, 3) `BoundingBox` <-> `Token`/`Sentence`/`Paragraph`')
+    out_bbox = metadata.add_output(AnnotationTypes.BoundingBox)
+    out_bbox.add_description('Bounding boxes of the detected text regions in the input images. No corresponding box '
+                             'for the entire image (`TextDocument`) region')
+    
+    metadata.add_parameter(name='tfLabel', default=[], type='string', multivalued=True,
+                           description='The label of the TimeFrame annotation to be processed. By default (`[]`), all '
+                                       'TimeFrame annotations will be processed, regardless of their `label` property '
+                                       'values.')
 
     return metadata
 

--- a/metadata.py
+++ b/metadata.py
@@ -27,9 +27,13 @@ def appmetadata() -> AppMetadata:
                     'https://pypi.org/project/python-doctr . The model is capable of detecting text regions in the '
                     'input image and recognizing text in the regions. The text-localized regions are organized '
                     'hierarchically by the model into "pages" > "blocks" > "lines" > "words", and this CLAMS app '
-                    'translated into `TextDocument`, `Paragraphs`, `Sentence`, and `Token` annotations that represent '
-                    'recognized text contents, then aligned to `BoundingBox` annotations that represent the detected '
-                    'geometries.',
+                    'translates them into `TextDocument`, `Paragraphs`, `Sentence`, and `Token` annotations to '
+                    'represent recognized text contents, then aligns them to `BoundingBox` annotations that represent '
+                    'the detected geometries. This hierarchical structure is also represented in the `TextDocument` '
+                    'annotation output as two newlines (`\\n\\n`) between "paragraphs", one newline (`\\n`) between '
+                    'the "lines", and one space (" ") between the "words". For the text recognition, the model is '
+                    'internally configured to use the "parseq" recognition model, and only works with English text '
+                    'at the moment.',
         app_license="Apache 2.0",
         identifier="doctr-wrapper",
         url="https://github.com/clamsproject/app-doctr-wrapper",
@@ -42,17 +46,23 @@ def appmetadata() -> AppMetadata:
                           '`representatives` property is present, the app will process videos still frames at the '
                           'underlying time point annotations that are referred to by the `representatives` property. '
                           'Otherwise, the app will process the middle frame of the video segment.')
-    metadata.add_output(DocumentTypes.TextDocument)
-    out_sent = metadata.add_output(at_type=Uri.SENTENCE)
-    out_sent.add_description('Translation of the recognized "text lines" in the processed input images')
-    out_para = metadata.add_output(at_type=Uri.PARAGRAPH)
-    out_para.add_description('Translation of the recognized "text blocks" in the processed input images')
-    out_tkn = metadata.add_output(at_type=Uri.TOKEN)
-    out_tkn.add_description('Translation of the recognized "text words" in the processed input images')
+    out_td = metadata.add_output(DocumentTypes.TextDocument, **{'@lang': 'en'})
+    out_td.add_description('Fully serialized text content of the recognized text in the input images. Serialization is'
+                           'done by concatenating `text` values of `Paragraph` annotations with two newline characters.')
+    out_tkn = metadata.add_output(at_type=Uri.TOKEN, text='*', word='*')
+    out_tkn.add_description('Translation of the recognized docTR "words" in the input images. `text` and `word` '
+                            'properties store the string values of the recognized text. The duplication is for keeping'
+                            'backward compatibility and consistency with `Paragraph` and `Sentence` annotations.')
+    out_sent = metadata.add_output(at_type=Uri.SENTENCE, text='*')
+    out_sent.add_description('Translation of the recognized docTR "lines" in the input images. `text` property stores '
+                             'the string value of space-joined words.')
+    out_para = metadata.add_output(at_type=Uri.PARAGRAPH, text='*')
+    out_para.add_description('Translation of the recognized docTR "blocks" in the input images. `text` property stores '
+                             'the string value of newline-joined sentences.')
     out_ali = metadata.add_output(AnnotationTypes.Alignment)
     out_ali.add_description('Alignments between 1) `TimePoint` <-> `TextDocument`, 2) `TimePoint` <-> '
                             '`Token`/`Sentence`/`Paragraph`, 3) `BoundingBox` <-> `Token`/`Sentence`/`Paragraph`')
-    out_bbox = metadata.add_output(AnnotationTypes.BoundingBox)
+    out_bbox = metadata.add_output(AnnotationTypes.BoundingBox, label='text')
     out_bbox.add_description('Bounding boxes of the detected text regions in the input images. No corresponding box '
                              'for the entire image (`TextDocument`) region')
     

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Make sure clams-python version is explicitly specified, at least the lower bound
 clams-python==1.2.0
 mmif-python[cv]
-python-doctr[torch]>=0.7.0
+python-doctr[torch]==0.8.1
 torch>=2.*
 numpy
 Pillow


### PR DESCRIPTION
fixes #2 and also implements 

- separation of `BoundingBox` annotations' `timePoint` properties into `TimePoint` annotations aligned with `TP`s (https://github.com/clamsproject/app-east-textdetection/issues/1) 
- handling of `TimeFrame` inputs without `representatives` properties (by picking the middle point as the representative)
- major refactoring and de-cluttering codebase