### PR TITLE
Fixed cuda re-initialization issue when multiprocessing

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,13 +11,14 @@ from typing import Tuple, Sequence
 
 import numpy as np
 import torch
+import torch.multiprocessing as mp
 from clams import ClamsApp, Restifier
 from doctr.models import ocr_predictor
 from lapps.discriminators import Uri
 from mmif import Mmif, View, Annotation, Document, AnnotationTypes, DocumentTypes
 from mmif.utils import video_document_helper as vdh
 
-
+mp.set_start_method('spawn', force=True)  # Force spawn to avoid issues with CUDA
 class DoctrWrapper(ClamsApp):
 
     def __init__(self):


### PR DESCRIPTION
## Issue description

Ran the app `doctr-wrapper` on both standalone and containerized ways, and faced error:
```
Cannot re-initialize CUDA in forked subprocess. To use CUDA with multiprocessing, you must use the 'spawn' start method
```

## Implementations

* Imported `torch.multiprocessing` module
* Forced the start method of multiprocess as `spawn` instead of `fork`, such that `multiprocessing.set_start_method('spawn', force=True)`
* Then placed the setting outside of the class 
